### PR TITLE
Fixed broken links in docs

### DIFF
--- a/docs/technical-docs/index.md
+++ b/docs/technical-docs/index.md
@@ -10,7 +10,7 @@ Artifacts are outputs.
 
 ## Nuggets
 
-[Nuggets](/technical-docs/nuggets/) are the "standard box" that all data fits into so we can easily add a lot of functionality around that data, without duplicating our efforts.
+[Nuggets](/docs/technical-docs/nuggets/) are the "standard box" that all data fits into so we can easily add a lot of functionality around that data, without duplicating our efforts.
 
 ## Platform
 
@@ -18,5 +18,5 @@ The platform is any part of this technology solution.
 
 ## Reactions
 
-[Reactions](/technical-docs/reactions/) represent a members' response to a [nugget](/technical-docs/nuggets/). We still need to define the set of reactions.
+[Reactions](/docs/technical-docs/reactions/) represent a members' response to a [nugget](/docs/technical-docs/nuggets/). We still need to define the set of reactions.
 

--- a/docs/technical-docs/reactions/index.md
+++ b/docs/technical-docs/reactions/index.md
@@ -1,6 +1,6 @@
 # Reactions
 
-Different nugeet types can have different sets of valid reactions.
+Different nugget types can have different sets of valid reactions.
 
 * Abstain
 * Agree


### PR DESCRIPTION
The links didn't have the correct path, and they 404'd